### PR TITLE
Use ParallelNotification instead of Notification to avoid overlapping

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/AppWidgetSet.gwt.xml
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/AppWidgetSet.gwt.xml
@@ -19,4 +19,6 @@
    <inherits name="org.eclipse.hawkbit.ui.rollout.groupschart.GroupsPieChart" />
    <inherits
       name="org.eclipse.hawkbit.ui.common.grid.selection.RangeSelectionWidgetset" /> 
+   <inherits
+      name="org.eclipse.hawkbit.ui.common.parallelnotification.ParallelNotificationWidgetset" /> 
 </module>

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/ErrorView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/ErrorView.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.hawkbit.ui;
 
+import org.eclipse.hawkbit.ui.common.parallelnotification.ParallelNotification;
 import org.eclipse.hawkbit.ui.menu.DashboardMenu;
 import org.eclipse.hawkbit.ui.menu.DashboardMenuItem;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
@@ -21,7 +22,6 @@ import com.vaadin.shared.Position;
 import com.vaadin.spring.annotation.SpringComponent;
 import com.vaadin.spring.annotation.UIScope;
 import com.vaadin.ui.Label;
-import com.vaadin.ui.Notification;
 import com.vaadin.ui.Notification.Type;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
@@ -63,7 +63,7 @@ public class ErrorView extends VerticalLayout implements View {
             return;
         }
         if (dashboardMenu.isAccessDenied(event.getViewName())) {
-            final Notification nt = new Notification(i18n.getMessage("message.accessdenied"),
+            final ParallelNotification nt = new ParallelNotification(i18n.getMessage("message.accessdenied"),
                     i18n.getMessage("message.accessdenied.view", event.getViewName()), Type.ERROR_MESSAGE, false);
             nt.setStyleName(SPUIStyleDefinitions.SP_NOTIFICATION_ERROR_MESSAGE_STYLE);
             nt.setPosition(Position.BOTTOM_RIGHT);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/selection/RangeSelectionWidgetset.gwt.xml
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/selection/RangeSelectionWidgetset.gwt.xml
@@ -16,4 +16,6 @@
    <inherits name="org.eclipse.hawkbit.ui.AppWidgetSet" />
    <inherits
       name="org.vaadin.alump.distributionbar.gwt.DistributionBarWidgetset" />
+
+    <inherits name="org.eclipse.hawkbit.ui.common.parallelnotification.ParallelNotificationWidgetset" />
 </module>

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/parallelnotification/ParallelNotification.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/parallelnotification/ParallelNotification.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2020 Bosch.IO GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.ui.common.parallelnotification;
+
+import com.vaadin.ui.Notification;
+
+/**
+ * Creates {@link Notification} that do not hide each other
+ *
+ */
+public class ParallelNotification extends Notification {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates notification
+     *
+     * @param caption
+     *            The message to show
+     */
+    public ParallelNotification(final String caption) {
+        super(caption);
+    }
+
+    /**
+     * Creates notification
+     *
+     * @param caption
+     *            The message to show
+     * @param type
+     *            The type of message
+     */
+    public ParallelNotification(final String caption, final Type type) {
+        super(caption, type);
+    }
+
+    /**
+     * Creates notification
+     *
+     * @param caption
+     *            The message caption
+     * @param description
+     *            The message description
+     */
+    public ParallelNotification(final String caption, final String description) {
+        super(caption, description);
+    }
+
+    /**
+     * Creates notification
+     *
+     * @param caption
+     *            The message caption
+     * @param description
+     *            The message description
+     * @param type
+     *            The type of message
+     */
+    public ParallelNotification(final String caption, final String description, final Type type) {
+        super(caption, description, type);
+    }
+
+    /**
+     * Creates notification
+     *
+     * @param caption
+     *            The message caption
+     * @param description
+     *            The message description
+     * @param type
+     *            The type of message
+     * @param htmlContentAllowed
+     *            Whether html in the caption and description should be
+     *            displayed as html or as plain text
+     */
+    public ParallelNotification(final String caption, final String description, final Type type,
+            final boolean htmlContentAllowed) {
+        super(caption, description, type, htmlContentAllowed);
+    }
+
+}

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/parallelnotification/ParallelNotificationWidgetset.gwt.xml
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/parallelnotification/ParallelNotificationWidgetset.gwt.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+    Copyright (c) 2020 Bosch.IO GmbH and others.
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -9,12 +9,13 @@
     http://www.eclipse.org/legal/epl-v10.html
 
 -->
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.8.2//EN" "http://gwtproject.org/doctype/2.8.2/gwt-module.dtd">
 <module>
-    <inherits name="com.vaadin.DefaultWidgetSet"/>
-    <inherits name="org.eclipse.hawkbit.ui.AppWidgetSet"/>
-    <inherits name="org.vaadin.alump.distributionbar.gwt.DistributionBarWidgetset"/>
-    <inherits name="com.github.gwtd3.D3"/>
+
+   <inherits name="com.vaadin.DefaultWidgetSet" />
+   <inherits name="org.eclipse.hawkbit.ui.AppWidgetSet" />
+
     <inherits name="org.eclipse.hawkbit.ui.common.grid.selection.RangeSelectionWidgetset" />
 
-    <inherits name="org.eclipse.hawkbit.ui.common.parallelnotification.ParallelNotificationWidgetset" />
+    <inherits name="org.vaadin.alump.distributionbar.gwt.DistributionBarWidgetset" />
 </module>

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/parallelnotification/client/ParallelNotificationConnector.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/parallelnotification/client/ParallelNotificationConnector.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2020 Bosch.IO GmbH and others.
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*/
+package org.eclipse.hawkbit.ui.common.parallelnotification.client;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.hawkbit.ui.common.parallelnotification.ParallelNotification;
+
+import com.google.gwt.dom.client.Style.Unit;
+import com.vaadin.client.ServerConnector;
+import com.vaadin.client.ui.VNotification;
+import com.vaadin.client.ui.notification.NotificationConnector;
+import com.vaadin.shared.ui.Connect;
+import com.vaadin.shared.ui.notification.NotificationServerRpc;
+import com.vaadin.shared.ui.notification.NotificationState;
+
+/**
+ * Connector for {@link ParallelNotification} that holds all active
+ * notifications of the current UI and positions them so they do not overlap.
+ */
+@Connect(value = ParallelNotification.class)
+public class ParallelNotificationConnector extends NotificationConnector {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Map<VNotification, Integer> notifications = new HashMap<>();
+
+    private transient VNotification notification;
+
+    @Override
+    protected void extend(final ServerConnector target) {
+        final NotificationState state = getState();
+        notification = VNotification.showNotification(target.getConnection(), state.caption, state.description,
+                state.htmlContentAllowed, getResourceUrl("icon"), state.styleName, state.position, state.delay);
+
+        notification.addCloseHandler(event -> {
+            notificationRemoved(notification);
+            if (getParent() == null) {
+                return;
+            }
+            final NotificationServerRpc rpc = getRpcProxy(NotificationServerRpc.class);
+            rpc.closed();
+            notification = null;
+        });
+
+        final int totalNotificationHeight = notifications.values().stream().reduce(0, Integer::sum);
+        setMarginBottom(notification, totalNotificationHeight);
+        notifications.put(notification, notification.getOffsetHeight());
+    }
+
+    @Override
+    public void onUnregister() {
+        super.onUnregister();
+        if (notification != null) {
+            notification.hide();
+            notification = null;
+        }
+    }
+
+    private static void notificationRemoved(final VNotification notificationRemoved) {
+        final int heightOfRemoved = notifications.get(notificationRemoved);
+        final double marginOfRemoved = getMarginBottom(notificationRemoved);
+        notifications.remove(notificationRemoved);
+        for (final VNotification n : notifications.keySet()) {
+            final double margin = getMarginBottom(n);
+            if (margin > marginOfRemoved) {
+                n.getElement().getStyle().setMarginBottom(margin - heightOfRemoved, Unit.PX);
+            }
+        }
+    }
+
+    private static void setMarginBottom(final VNotification notification, final double margin) {
+        notification.getElement().getStyle().setMarginBottom(margin, Unit.PX);
+    }
+
+    private static double getMarginBottom(final VNotification notification) {
+        try {
+            return Double.valueOf(notification.getElement().getStyle().getMarginBottom().replace("px", ""));
+        } catch (final NumberFormatException e) {
+            return 0;
+        }
+    }
+}

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/HawkbitErrorNotificationMessage.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/HawkbitErrorNotificationMessage.java
@@ -8,15 +8,15 @@
  */
 package org.eclipse.hawkbit.ui.components;
 
+import org.eclipse.hawkbit.ui.common.parallelnotification.ParallelNotification;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 
 import com.vaadin.shared.Position;
-import com.vaadin.ui.Notification;
 
 /**
  * Notification message component for displaying errors in the UI.
  */
-public class HawkbitErrorNotificationMessage extends Notification {
+public class HawkbitErrorNotificationMessage extends ParallelNotification {
 
     private static final long serialVersionUID = -6512576924243195753L;
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TextFieldSuggestionBox.gwt.xml
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TextFieldSuggestionBox.gwt.xml
@@ -14,4 +14,6 @@
     <inherits name="org.eclipse.hawkbit.ui.AppWidgetSet" />
     <inherits name="org.vaadin.alump.distributionbar.gwt.DistributionBarWidgetset" />
     <inherits name="org.eclipse.hawkbit.ui.common.grid.selection.RangeSelectionWidgetset" />
+
+    <inherits name="org.eclipse.hawkbit.ui.common.parallelnotification.ParallelNotificationWidgetset" />
 </module>

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/login/AbstractHawkbitLoginUI.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/login/AbstractHawkbitLoginUI.java
@@ -16,6 +16,7 @@ import org.eclipse.hawkbit.im.authentication.TenantUserPasswordAuthenticationTok
 import org.eclipse.hawkbit.ui.AbstractHawkbitUI;
 import org.eclipse.hawkbit.ui.UiProperties;
 import org.eclipse.hawkbit.ui.common.data.proxies.ProxyLoginCredentials;
+import org.eclipse.hawkbit.ui.common.parallelnotification.ParallelNotification;
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
 import org.eclipse.hawkbit.ui.themes.HawkbitTheme;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
@@ -55,7 +56,6 @@ import com.vaadin.ui.CustomLayout;
 import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.Link;
-import com.vaadin.ui.Notification;
 import com.vaadin.ui.PasswordField;
 import com.vaadin.ui.TextField;
 import com.vaadin.ui.UI;
@@ -285,7 +285,7 @@ public abstract class AbstractHawkbitLoginUI extends UI {
     }
 
     private void loginCredentialsExpiredNotification() {
-        final Notification notification = new Notification(
+        final ParallelNotification notification = new ParallelNotification(
                 i18n.getMessage("notification.login.failed.credentialsexpired.title"));
         notification.setDescription(i18n.getMessage("notification.login.failed.credentialsexpired.description"));
         notification.setDelayMsec(10_000);
@@ -296,7 +296,8 @@ public abstract class AbstractHawkbitLoginUI extends UI {
     }
 
     private void loginAuthenticationFailedNotification() {
-        final Notification notification = new Notification(i18n.getMessage("notification.login.failed.title"));
+        final ParallelNotification notification = new ParallelNotification(
+                i18n.getMessage("notification.login.failed.title"));
         notification.setDescription(i18n.getMessage("notification.login.failed.description"));
         notification.setHtmlContentAllowed(true);
         notification.setStyleName("error closable");

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/UINotification.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/UINotification.java
@@ -10,13 +10,14 @@ package org.eclipse.hawkbit.ui.utils;
 
 import java.io.Serializable;
 
+import org.eclipse.hawkbit.ui.common.parallelnotification.ParallelNotification;
+
 import com.vaadin.icons.VaadinIcons;
 import com.vaadin.server.Page;
 import com.vaadin.server.Resource;
 import com.vaadin.shared.Position;
 import com.vaadin.spring.annotation.SpringComponent;
 import com.vaadin.spring.annotation.UIScope;
-import com.vaadin.ui.Notification;
 
 /**
  * Show success, warning and error messages.
@@ -74,7 +75,7 @@ public class UINotification implements Serializable {
 
     private static void showNotification(final String styleName, final String caption, final String description,
             final Resource icon, final Boolean autoClose) {
-        final Notification notification = new Notification(caption, description);
+        final ParallelNotification notification = new ParallelNotification(caption, description);
 
         notification.setIcon(icon);
         notification.setStyleName(styleName);


### PR DESCRIPTION
Use a copie of the client-side vaadin notification class that additionally keeps track of all open notifications and positions them so that they do not overlap.
The notifications are saved in a map with their initial height because this value is needed after they are removed, at which point their actual height is zero.