### PR TITLE
Enforce decoding in authentication check (#1362)

### DIFF
--- a/hawkbit-http-security/src/main/java/org/eclipse/hawkbit/security/AbstractHttpControllerAuthenticationFilter.java
+++ b/hawkbit-http-security/src/main/java/org/eclipse/hawkbit/security/AbstractHttpControllerAuthenticationFilter.java
@@ -24,6 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
 import org.eclipse.hawkbit.security.DmfTenantSecurityToken.FileResource;
 import org.eclipse.hawkbit.tenancy.TenantAware;
+import org.eclipse.hawkbit.util.UrlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
@@ -135,8 +136,8 @@ public abstract class AbstractHttpControllerAuthenticationFilter extends Abstrac
             LOG.debug("retrieving principal from URI request {}", requestURI);
             final Map<String, String> extractUriTemplateVariables = pathExtractor
                     .extractUriTemplateVariables(request.getContextPath() + CONTROLLER_REQUEST_ANT_PATTERN, requestURI);
-            final String controllerId = extractUriTemplateVariables.get(CONTROLLER_ID_PLACE_HOLDER);
-            final String tenant = extractUriTemplateVariables.get(TENANT_PLACE_HOLDER);
+            final String controllerId = UrlUtils.decodeUriValue(extractUriTemplateVariables.get(CONTROLLER_ID_PLACE_HOLDER));
+            final String tenant = UrlUtils.decodeUriValue(extractUriTemplateVariables.get(TENANT_PLACE_HOLDER));
             if (LOG.isTraceEnabled()) {
                 LOG.trace("Parsed tenant {} and controllerId {} from path request {}", tenant, controllerId,
                         requestURI);
@@ -146,7 +147,7 @@ public abstract class AbstractHttpControllerAuthenticationFilter extends Abstrac
             LOG.debug("retrieving path variables from URI request {}", requestURI);
             final Map<String, String> extractUriTemplateVariables = pathExtractor.extractUriTemplateVariables(
                     request.getContextPath() + CONTROLLER_DL_REQUEST_ANT_PATTERN, requestURI);
-            final String tenant = extractUriTemplateVariables.get(TENANT_PLACE_HOLDER);
+            final String tenant = UrlUtils.decodeUriValue(extractUriTemplateVariables.get(TENANT_PLACE_HOLDER));
             if (LOG.isTraceEnabled()) {
                 LOG.trace("Parsed tenant {} from path request {}", tenant, requestURI);
             }

--- a/hawkbit-http-security/src/main/java/org/eclipse/hawkbit/security/ControllerTenantAwareAuthenticationDetailsSource.java
+++ b/hawkbit-http-security/src/main/java/org/eclipse/hawkbit/security/ControllerTenantAwareAuthenticationDetailsSource.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
 import org.eclipse.hawkbit.im.authentication.TenantAwareAuthenticationDetails;
+import org.eclipse.hawkbit.util.UrlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AuthenticationDetailsSource;
@@ -60,6 +61,6 @@ public class ControllerTenantAwareAuthenticationDetailsSource
             LOGGER.trace("Parsed path variables {} using tenant {}", extractUriTemplateVariables,
                     extractUriTemplateVariables.get(TENANT_PLACE_HOLDER));
         }
-        return extractUriTemplateVariables.get(TENANT_PLACE_HOLDER);
+        return UrlUtils.decodeUriValue(extractUriTemplateVariables.get(TENANT_PLACE_HOLDER));
     }
 }

--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/util/UrlUtils.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/util/UrlUtils.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2023 Bosch.IO GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.util;
+
+import org.springframework.web.util.UriUtils;
+
+import java.nio.charset.StandardCharsets;
+
+public class UrlUtils {
+
+  private UrlUtils() {
+    // Util classes should not have public constructors
+  }
+
+  public static String decodeUriValue(String value) {
+    return UriUtils.decode(value, StandardCharsets.UTF_8);
+  }
+
+}

--- a/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/HeaderAuthentication.java
+++ b/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/HeaderAuthentication.java
@@ -16,7 +16,7 @@ package org.eclipse.hawkbit.security;
  *
  *
  */
-public final class HeaderAuthentication {
+final class HeaderAuthentication {
     private final String controllerId;
     private final String headerAuth;
 


### PR DESCRIPTION
* Enforce decoding in authentication check +Enforce decoding of controllerId when authentication is performed for the reverse proxy use case
* Remove unused imports



* Switch approach to decode retrieved values from map



* Remove unused imports



* Style improve



* Move logic to separate class



* Remove TODO comment



* Hide public constructor in Util class



---------